### PR TITLE
Disable backups for android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="nl.windesheim.energietransitie.warmtewachter">
 
     <application
-            android:allowBackup="true"
+            android:allowBackup="false"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
Disables backups for Android. The backups caused unexpected behaviour. Data such as localStorage and the granting or denying of permissions is persistent after uninstalling and then reinstalling the app. As this was not as intended and we do not know the extent to which the backup can influence the application we've now disabled the backups on android. This is solely the case on Android. iOS removes all data when an app is removed from the device.