### PR TITLE
Fix instruction iframe width and button padding

### DIFF
--- a/src/Pages/Instructions.tsx
+++ b/src/Pages/Instructions.tsx
@@ -12,7 +12,8 @@ import { makeStyles } from '../theme/makeStyles';
 const useStyles = makeStyles({
     iframe: {
         border: 'none',
-        flexGrow: 1
+        flexGrow: 1,
+        maxWidth: '100%'
     }
 });
 

--- a/src/base-components/Button/Button.tsx
+++ b/src/base-components/Button/Button.tsx
@@ -16,8 +16,8 @@ const useStyles = makeStyles<'container'|'icon', ButtonProps>((theme) => ({
             || 'row'),
         cursor: 'pointer',
         fontSize: 18,
-        height: 40,
-        padding: '0 10px',
+        minHeight: 40,
+        padding: '5px 10px',
         borderRadius: 4,
         lineHeight: 1,
         color: theme.colors.white,
@@ -25,6 +25,7 @@ const useStyles = makeStyles<'container'|'icon', ButtonProps>((theme) => ({
         fontWeight: 600,
         background: theme.colors.statusOK,
         justifyContent: 'center',
+        textAlign: 'center',
 
         '&:hover::after': {
             content: '""',


### PR DESCRIPTION
 - Added `maxWidth` to `Instructions` Page `iframe`.
 - Added `minHeight` and padding to the `Button` base-component.
 - Added `textAlign: center` to the `Button` base-component as fallback for text wrapping.