### PR TITLE
Force Portrait Mode on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
                 android:name="nl.windesheim.energietransitie.warmtewachter.MainActivity"
                 android:label="@string/title_activity_main"
                 android:theme="@style/AppTheme.NoActionBarLaunch"
-                android:launchMode="singleTask">
+                android:launchMode="singleTask"
+                android:screenOrientation="sensorPortrait">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
Forces Portrait Mode on Android. Or basically disable Landscape mode. Already the case on iOS.