### PR TITLE
Fix portal positioning

### DIFF
--- a/src/base-components/Portal/Portal.tsx
+++ b/src/base-components/Portal/Portal.tsx
@@ -8,8 +8,15 @@ const useStyles = makeStyles(theme => ({
     container: {
         width: '100%',
         height: '100%',
-        position: 'relative',
+        position: 'absolute',
+        top: 0,
+        left: 0,
         zIndex: theme.zLayers.portal
+    },
+    content: {
+        width: '100%',
+        height: '100%',
+        position: 'relative'
     }
 }));
 
@@ -27,6 +34,10 @@ export const Portal: FC<PortalProps> = (props) => {
         const portalNode = document.createElement('div');
         portalNode.id = name;
         portalNode.className = classNames(classes.container, className);
+
+        const portalContentNode = document.createElement('div');
+        portalContentNode.className = classNames(classes.content);
+
         document.body.appendChild(portalNode)
         setPortalNode(portalNode);
 


### PR DESCRIPTION
Changes;
 - Set the positioning of the root Portal container to `absolute`.
 - Added a content wrapper to the Portal with `relative` positioning.
 
This fixes both the `QRScanBoundaries` and the `ErrorModal`.

Corresponding Trello issues;
 - [Fix dead end upon first measurement timeout](https://trello.com/c/H765Nz9B)
 - [scanning guides are missing from preview](https://trello.com/c/xtzy2yvE)